### PR TITLE
Eats less CPU

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.8.0
 commit = True
 tag = True
 

--- a/zero_netcat/zero_netcat.py
+++ b/zero_netcat/zero_netcat.py
@@ -2,6 +2,9 @@
 
 import six, sys, argparse, zmq, codecs, os, zmq.devices, time
 from six.moves import range
+import select
+import ctypes
+from ctypes import *
 
 # zeronc <bind|connect> <type> <address>
 
@@ -14,6 +17,34 @@ SOCKET_FROM_STR = {
 
 SENDS = ['pub', 'push']
 RECEIVES = ['sub', 'pull']
+
+LIBC = CDLL(None)
+
+# Shit just got real
+
+
+# File API.
+#
+# A FILE_ptr type is used instead of c_void_p because technically a pointer
+# to structure can have a different size or alignment to a void pointer.
+#
+# Note that the file api may change.
+#
+
+class FILE(ctypes.Structure):
+    pass
+FILE_ptr = ctypes.POINTER(FILE)
+
+PyFile_FromFile = ctypes.pythonapi.PyFile_FromFile
+PyFile_FromFile.restype = ctypes.py_object
+PyFile_FromFile.argtypes = [FILE_ptr,
+                            ctypes.c_char_p,
+                            ctypes.c_char_p,
+                            ctypes.CFUNCTYPE(ctypes.c_int, FILE_ptr)]
+
+PyFile_AsFile = ctypes.pythonapi.PyFile_AsFile
+PyFile_AsFile.restype = FILE_ptr
+PyFile_AsFile.argtypes = [ctypes.py_object]
 
 class AddressAction(argparse.Action):
     def __call__(self, parent_parser, namespace, values, option_string=None):
@@ -31,45 +62,39 @@ def main(args=sys.argv[1:]):
     parser.add_argument('--send-hwm', type=int, default=1000)
     parser.add_argument('--receive-hwm', type=int, default=1000)
     parser.add_argument('--subscribe', action='append')
-    parser.add_argument('--topic', default='default_topic')
+    parser.add_argument('--topic', default=None)
     parser.add_argument('--buffer-size', type=int, default=100)
-    parser.add_argument('--output', default='')
     parser.add_argument('address', nargs='+', action=AddressAction)
     options = parser.parse_args(args)
     context = zmq.Context.instance(options.io_threads)
     context.set(zmq.IPV6, 1 if options.ipv6 else 0)
     send(context, options) if options.address[0].type in SENDS else receive(context, options)
 
-
 def send(context, options):
-    bcast = context.socket(zmq.PUB)
-    bcast.bind('inproc://bcast')
+    if len(options.address) != 1:
+        raise "Only one output address is supported"
 
-    for addr in options.address:
-        proxy = zmq.devices.ThreadProxy(zmq.SUB, SOCKET_FROM_STR[addr.type])
-        proxy.setsockopt_out(zmq.SNDHWM, options.send_hwm)
-        if addr.bind_connect == 'bind':
-            proxy.bind_out(addr.address)
-        else:
-            proxy.connect_out(addr.address)
-        proxy.setsockopt_in(zmq.SUBSCRIBE, six.u('').encode('utf-8'))
-        proxy.connect_in('inproc://bcast')
-        proxy.start()
+    addr = options.address[0]
+    socket = context.socket(SOCKET_FROM_STR[addr.type])
+    socket.set(zmq.SNDHWM, options.send_hwm)
+    if addr.bind_connect == 'bind':
+        socket.bind(addr.address)
+    else:
+        socket.connect(addr.address)
 
     input = codecs.getreader('utf-8')(os.fdopen(sys.stdin.fileno(), 'r', options.buffer_size))
     while True:
         line = input.readline()
         if not line: break
-        bcast.send_multipart([options.topic.encode('utf-8'), line.rstrip().encode('utf-8')])
+        if options.topic == None:
+            socket.send(line.rstrip().encode('utf-8'))
+        else:
+            socket.send_multipart([options.topic.encode('utf-8'), line.rstrip().encode('utf-8')])
 
 
 def receive(context, options):
     input = context.socket(zmq.PULL)
     input.bind('inproc://input')
-    output = sys.stdout.fileno()
-    fdout = len(options.output) > 0
-    if fdout:
-        output = os.open(options.output, os.O_WRONLY)
 
     for addr in options.address:
         proxy = zmq.devices.ThreadProxy(SOCKET_FROM_STR[addr.type], zmq.PUSH)
@@ -88,15 +113,14 @@ def receive(context, options):
         proxy.connect_out('inproc://input')
         proxy.start()
 
-    if fdout:
-        while True:
-            input.recv_string() #topic
-            os.write(output, input.recv_string().encode('utf-8'))
-            os.write(output, '\n'.encode('utf-8'))
-    else:
-        while True:
-            input.recv_string() #topic
-            six.print_(input.recv_string().encode('utf-8'), flush=True)
+    poller = select.poll()
+    poller.register(sys.stdout, select.POLLOUT)
+    while True:
+        poller.poll()
+        input.recv_string() #topic
+        buf = input.recv_string().encode('utf-8')
+
+        six.print_(input.recv_string().encode('utf-8'), flush=True)
 
 
 

--- a/zero_netcat/zero_netcat.py
+++ b/zero_netcat/zero_netcat.py
@@ -1,59 +1,31 @@
 # -*- coding: utf-8 -*-
 
-import six, sys, argparse, zmq, codecs, os, zmq.devices, time
+import six, sys, argparse, zmq, codecs, os, zmq.devices
 from six.moves import range
-import select
-import ctypes
-from ctypes import *
 
 # zeronc <bind|connect> <type> <address>
 
 SOCKET_FROM_STR = {
-    'pub' : zmq.PUB,
-    'sub' : zmq.SUB,
-    'push' : zmq.PUSH,
-    'pull' : zmq.PULL
+    'pub': zmq.PUB,
+    'sub': zmq.SUB,
+    'push': zmq.PUSH,
+    'pull': zmq.PULL
 }
 
 SENDS = ['pub', 'push']
 RECEIVES = ['sub', 'pull']
 
-LIBC = CDLL(None)
-
-# Shit just got real
-
-
-# File API.
-#
-# A FILE_ptr type is used instead of c_void_p because technically a pointer
-# to structure can have a different size or alignment to a void pointer.
-#
-# Note that the file api may change.
-#
-
-class FILE(ctypes.Structure):
-    pass
-FILE_ptr = ctypes.POINTER(FILE)
-
-PyFile_FromFile = ctypes.pythonapi.PyFile_FromFile
-PyFile_FromFile.restype = ctypes.py_object
-PyFile_FromFile.argtypes = [FILE_ptr,
-                            ctypes.c_char_p,
-                            ctypes.c_char_p,
-                            ctypes.CFUNCTYPE(ctypes.c_int, FILE_ptr)]
-
-PyFile_AsFile = ctypes.pythonapi.PyFile_AsFile
-PyFile_AsFile.restype = FILE_ptr
-PyFile_AsFile.argtypes = [ctypes.py_object]
 
 class AddressAction(argparse.Action):
     def __call__(self, parent_parser, namespace, values, option_string=None):
-        if len(values) % 3 != 0: raise argparse.ArgumentError(self, "Address requires three arguments per address")
+        if len(values) % 3 != 0:
+            raise argparse.ArgumentError(self, "Address requires three arguments per address")
         parser = argparse.ArgumentParser()
         parser.add_argument('bind_connect', choices=['bind', 'connect'])
         parser.add_argument('type', choices=SOCKET_FROM_STR.keys(), metavar='type')
         parser.add_argument('address')
-        setattr(namespace, self.dest, [parser.parse_args(values[i:i+3]) for i in range(0, len(values), 3)])
+        setattr(namespace, self.dest, [parser.parse_args(values[i:i + 3]) for i in range(0, len(values), 3)])
+
 
 def main(args=sys.argv[1:]):
     parser = argparse.ArgumentParser(description='Connects stdin and stdout to a ZeroMQ socket')
@@ -70,6 +42,7 @@ def main(args=sys.argv[1:]):
     context.set(zmq.IPV6, 1 if options.ipv6 else 0)
     send(context, options) if options.address[0].type in SENDS else receive(context, options)
 
+
 def send(context, options):
     if len(options.address) != 1:
         raise "Only one output address is supported"
@@ -82,45 +55,41 @@ def send(context, options):
     else:
         socket.connect(addr.address)
 
-    input = codecs.getreader('utf-8')(os.fdopen(sys.stdin.fileno(), 'r', options.buffer_size))
+    wrapped_input = codecs.getreader('utf-8')(os.fdopen(sys.stdin.fileno(), 'r', options.buffer_size))
     while True:
-        line = input.readline()
-        if not line: break
-        if options.topic == None:
+        line = wrapped_input.readline()
+        if not line:
+            break
+        if options.topic is None:
             socket.send(line.rstrip().encode('utf-8'))
         else:
             socket.send_multipart([options.topic.encode('utf-8'), line.rstrip().encode('utf-8')])
 
 
 def receive(context, options):
-    input = context.socket(zmq.PULL)
-    input.bind('inproc://input')
-
+    poller = zmq.Poller()
+    addrs = {}
     for addr in options.address:
-        proxy = zmq.devices.ThreadProxy(SOCKET_FROM_STR[addr.type], zmq.PUSH)
-        proxy.setsockopt_in(zmq.RCVHWM, options.receive_hwm)
+        socket = context.socket(SOCKET_FROM_STR[addr.type])
+        socket.set(zmq.RCVHWM, options.receive_hwm)
+
         if addr.type == 'sub':
             if not options.subscribe:
-                proxy.setsockopt_in(zmq.SUBSCRIBE, six.u('').encode('utf-8'))
+                socket.set_string(zmq.SUBSCRIBE, six.u('').encode('utf-8'))
             else:
                 for topic in options.subscribe:
-                    proxy.setsockopt_in(zmq.subscribe, six.u(topic).encode('utf-8'))
+                    socket.set_string(zmq.SUBSCRIBE, six.u(topic).encode('utf-8'))
 
         if addr.bind_connect == 'bind':
-            proxy.bind_in(addr.address)
+            socket.bind(addr.address)
         else:
-            proxy.connect_in(addr.address)
-        proxy.connect_out('inproc://input')
-        proxy.start()
+            socket.connect(addr.address)
+        poller.register(socket, zmq.POLLIN)
+        addrs[socket] = addr
 
-    poller = select.poll()
-    poller.register(sys.stdout, select.POLLOUT)
     while True:
-        poller.poll()
-        input.recv_string() #topic
-        buf = input.recv_string().encode('utf-8')
-
-        six.print_(input.recv_string().encode('utf-8'), flush=True)
-
-
-
+        events = dict(poller.poll())
+        for socket in events.keys():
+            if addrs[socket].type == 'sub':
+                socket.recv(copy=False)  # topic
+            six.print_(socket.recv_string().encode('utf-8'), flush=True)


### PR DESCRIPTION
Had an issue where a slow consumer of pull/sub output would cause zeronc process to spike to 100% CPU. After getting angry with Python, it turned out to be excessive polling in the zmq.proxy implementation, so those got removed. 

Additionally restricted it to one publish socket per process. This makes it more predictable anyway.
